### PR TITLE
fix(sign-windows): pin SSD 2.9.14, dismiss version-check modal, add CI screenshots

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,6 +380,13 @@ jobs:
           scripts/windows-sign.sh dist/unsigned/*.exe
           rm -f "$ARCHIVE"
           cd dist && zip -j "$(basename "$ARCHIVE" .zip).zip" unsigned/*.exe && cd ..
+      - name: Upload sign-windows screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sign-windows-screens
+          path: /tmp/sign-screens/
+          if-no-files-found: ignore
       - uses: actions/upload-artifact@v4
         if: env.HAS_SIGNING != ''
         with:

--- a/scripts/windows-sign.sh
+++ b/scripts/windows-sign.sh
@@ -54,7 +54,7 @@ echo "==> Dependencies installed"
 
 # --- Install SimplySign Desktop ---
 
-SSD_URL="https://files.certum.eu/software/SimplySignDesktop/Linux-Ubuntu/2.9.13-9.4.2.0/SimplySignDesktop-2.9.13-9.4.2.0-x86_64-prod-ubuntu.bin"
+SSD_URL="https://files.certum.eu/software/SimplySignDesktop/Linux-Ubuntu/2.9.14-9.4.3.0/SimplySignDesktop-2.9.14-9.4.3.0-x86_64-prod-ubuntu.bin"
 SSD_DIR="/opt/SimplySignDesktop"
 
 if [[ ! -d "$SSD_DIR" ]]; then
@@ -119,6 +119,19 @@ echo "==> Launching SimplySign Desktop..."
 SSD_PID=$!
 sleep 8
 dump_windows
+
+# Dismiss "Newer application version is available" modal if it appeared.
+# It steals focus from the login form; if SSD ever falls behind Certum's
+# advertised version again we still want signing to proceed.
+VERSION_MODAL=$(xdotool search --name "Application version check" 2>/dev/null | head -1 || true)
+if [[ -n "$VERSION_MODAL" ]]; then
+    echo "==> Dismissing version-check modal (wid=$VERSION_MODAL)"
+    xdotool windowactivate --sync "$VERSION_MODAL" 2>/dev/null || true
+    sleep 0.5
+    xdotool key --window "$VERSION_MODAL" Escape
+    sleep 1
+    dump_windows
+fi
 
 echo "==> Searching for login window..."
 WINDOW_ID=$(timeout 30 xdotool search --sync --onlyvisible --name "SimplySign" 2>/dev/null | head -1 || true)

--- a/scripts/windows-sign.sh
+++ b/scripts/windows-sign.sh
@@ -32,12 +32,21 @@ for f in "$@"; do
     fi
 done
 
+dump_windows() {
+    echo "==> X11 windows snapshot:"
+    for wid in $(xdotool search --name "" 2>/dev/null); do
+        local name
+        name=$(xdotool getwindowname "$wid" 2>/dev/null || true)
+        [[ -n "$name" ]] && echo "    wid=$wid name='$name'"
+    done
+}
+
 # --- Install dependencies ---
 
 echo "==> Installing dependencies..."
 sudo apt-get update -qq
 sudo apt-get install -y -qq \
-    xvfb xdotool oathtool osslsigncode \
+    xvfb xdotool oathtool osslsigncode scrot \
     p11-kit opensc stalonetray \
     libpulse-mainloop-glib0 libxss1 libnss3 libxkbcommon0 \
     > /dev/null 2>&1
@@ -92,6 +101,14 @@ XVFB_PID=$!
 export DISPLAY=:99
 sleep 2
 
+mkdir -p /tmp/sign-screens
+( while true; do
+    scrot -o "/tmp/sign-screens/$(date +%s.%N).png" 2>/dev/null
+    sleep 2
+  done ) &
+SCROT_PID=$!
+trap "kill $SCROT_PID 2>/dev/null || true" EXIT
+
 stalonetray --geometry 1x1+0+0 --grow-gravity W &
 sleep 1
 
@@ -101,6 +118,7 @@ echo "==> Launching SimplySign Desktop..."
 "$SSD_EXE" &
 SSD_PID=$!
 sleep 8
+dump_windows
 
 echo "==> Searching for login window..."
 WINDOW_ID=$(timeout 30 xdotool search --sync --onlyvisible --name "SimplySign" 2>/dev/null | head -1 || true)
@@ -120,6 +138,8 @@ fi
 
 xdotool windowactivate --sync "$WINDOW_ID" 2>/dev/null || true
 sleep 1
+
+dump_windows
 
 # Generate TOTP right before typing to avoid expiration
 TOTP=$(oathtool --totp=sha256 -b --digits=6 "$CERTUM_TOTP_SECRET")
@@ -172,6 +192,7 @@ if [[ "$TOKEN_READY" != "true" ]]; then
     exit 1
 fi
 echo "==> PKCS#11 token available"
+dump_windows
 
 # --- Start p11-kit server ---
 
@@ -211,6 +232,7 @@ echo "==> Key alias: $KEY_ALIAS"
 
 for f in "$@"; do
     echo "==> Signing $f..."
+    dump_windows
 
     java -jar "$JSIGN_JAR" \
         --storetype PKCS11 \


### PR DESCRIPTION
## Summary

The `sign-windows` job in the release workflow has been failing since v0.15.0
on 2026-05-03. Root cause turned out to be a SimplySign Desktop "Newer
application version is available (2.9.14)" modal popping in front of the
login form right when xdotool started typing — it stole focus, swallowed
the credentials and TOTP, and left the WebKit OAuth panel in a state where
the second `Get Softcards List` call (jsign signing) opened an empty panel
that Certum cancelled after 60s.

Three changes:

- Pin SimplySign Desktop to `2.9.14-9.4.3.0` so the version-check modal
  doesn't appear in the first place.
- Defensive `Escape` on any `Application version check` window before the
  credential-typing flow, so we don't break again the next time Certum
  advertises a newer release.
- Screenshot loop + `dump_windows` X11 enumeration in `windows-sign.sh`,
  plus an `if: failure()` artifact upload in the release workflow. Costs
  nothing while green; surfaces the next regression in seconds instead of
  guessing through 7-min CI cycles.

## Test plan

- [x] CI dispatch on the branch fails as expected before the fix
      (run 25290238615) — uploaded screenshots showed the version-check
      modal sitting on top of the login form.
- [x] CI dispatch on the branch succeeds after the fix
      (run 25290930608) — `vykar.exe`, `vykar-server.exe`, `vykar-gui.exe`
      all signed and verified with RFC3161 timestamps.
- [ ] Re-tag `v0.15.0` and confirm the full release workflow succeeds
      end-to-end including `publish`.