### PR TITLE
fix(backup): skip xattr reads on dataless inodes

### DIFF
--- a/crates/vykar-core/src/commands/backup/walk/mod.rs
+++ b/crates/vykar-core/src/commands/backup/walk/mod.rs
@@ -185,7 +185,11 @@ pub(super) fn materialize_item(walked: WalkedEntry, xattrs_enabled: bool) -> Res
         xattrs: None,
     };
 
-    if xattrs_enabled {
+    // Skip xattrs on dataless inodes: macOS `getxattr` on FileProvider-managed
+    // attrs round-trips through `fileproviderd`, serializing the single-thread
+    // walker. Dataless entries are either propagated from the parent snapshot
+    // (xattrs come from the cached Item) or routed to SkipDataless.
+    if xattrs_enabled && !metadata_summary.is_dataless {
         item.xattrs = read_item_xattrs(&walked.abs_path);
     }
 
@@ -576,6 +580,69 @@ mod tests {
         assert!(should_skip_for_device(true, 42, 43));
         assert!(!should_skip_for_device(true, 42, 42));
         assert!(!should_skip_for_device(false, 42, 43));
+    }
+
+    /// Regression: dataless inodes must NOT trigger `read_item_xattrs`.
+    /// On macOS, `getxattr` on FileProvider-managed attrs round-trips through
+    /// `fileproviderd` and can stall the (single-threaded) walker for seconds
+    /// per file. Confirms the dataless guard added to `materialize_item` —
+    /// when `is_dataless: true`, the Item must come back with `xattrs: None`
+    /// even when the underlying file has xattrs on disk and `xattrs_enabled`
+    /// is set. The companion `is_dataless: false` case proves the read path
+    /// still fires when not gated.
+    #[cfg(unix)]
+    #[test]
+    fn materialize_item_skips_xattrs_on_dataless() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("placeholder");
+        std::fs::write(&path, b"x").unwrap();
+        // Best-effort xattr write — bail the test if the tempdir's filesystem
+        // doesn't support xattrs (e.g. tmpfs on some Linux configs); the
+        // cross-platform xattrs_supported() flag does not detect that case.
+        if xattr::set(&path, "user.vykar_test", b"v").is_err() {
+            return;
+        }
+
+        let real_meta = std::fs::symlink_metadata(&path).unwrap();
+        let file_type = real_meta.file_type();
+        let mut summary = fs::summarize_metadata(&real_meta, &file_type);
+        summary.is_dataless = true;
+
+        let walked = inode_walk::WalkedEntry {
+            abs_path: path.clone(),
+            metadata: summary,
+            file_type,
+            snapshot_path: "placeholder".into(),
+        };
+
+        match materialize_item(walked, true).unwrap() {
+            Materialized::Entry { item, .. } => {
+                assert!(
+                    item.xattrs.is_none(),
+                    "dataless inodes must not be xattr-read",
+                );
+            }
+            other => panic!("expected Entry, got {other:?}"),
+        }
+
+        // Sanity: same file with `is_dataless: false` must populate xattrs.
+        let mut summary_warm = fs::summarize_metadata(&real_meta, &file_type);
+        summary_warm.is_dataless = false;
+        let walked_warm = inode_walk::WalkedEntry {
+            abs_path: path,
+            metadata: summary_warm,
+            file_type,
+            snapshot_path: "placeholder".into(),
+        };
+        match materialize_item(walked_warm, true).unwrap() {
+            Materialized::Entry { item, .. } => {
+                assert!(
+                    item.xattrs.is_some(),
+                    "warm files with xattrs_enabled must populate xattrs",
+                );
+            }
+            other => panic!("expected Entry, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/vykar-core/src/commands/backup/walk/mod.rs
+++ b/crates/vykar-core/src/commands/backup/walk/mod.rs
@@ -185,10 +185,17 @@ pub(super) fn materialize_item(walked: WalkedEntry, xattrs_enabled: bool) -> Res
         xattrs: None,
     };
 
-    // Skip xattrs on dataless inodes: macOS `getxattr` on FileProvider-managed
-    // attrs round-trips through `fileproviderd`, serializing the single-thread
-    // walker. Dataless entries are either propagated from the parent snapshot
-    // (xattrs come from the cached Item) or routed to SkipDataless.
+    // Skip xattrs on dataless inodes: on macOS, `getxattr` for FileProvider-
+    // managed attrs round-trips through `fileproviderd` and serialises this
+    // single-threaded walker. See issue #133 for the diagnosis.
+    //
+    // Trade-off: on the cache-hit path, `lookup_dataless` returns only chunk
+    // refs (not xattrs), so dataless cache hits now record `xattrs: None` in
+    // the new snapshot. Restoring a dataless file therefore loses any
+    // user-set xattrs (Finder tags etc.) it had on the source. This is
+    // deliberate — preserving them would require either re-reading from disk
+    // (defeats the fix) or threading them through ParentReuseIndex (out of
+    // scope; see #133 fix #2).
     if xattrs_enabled && !metadata_summary.is_dataless {
         item.xattrs = read_item_xattrs(&walked.abs_path);
     }


### PR DESCRIPTION
## Summary

`materialize_item` was reading xattrs on every walked file regardless of whether the inode was a `SF_DATALESS` (FileProvider) placeholder. On macOS iCloud-managed paths, `getxattr` for FileProvider-tracked attributes round-trips through `fileproviderd`, which serializes the (already single-threaded) walker. With hundreds of small dataless files in a directory, one slow daemon round-trip per file is enough to freeze the whole backup pipeline — workers and the consumer have nothing to do while the walker is parked in `getxattr`.

Dataless entries are either propagated from the parent snapshot via `lookup_dataless` (which preserves the cached Item's xattrs) or routed to `CacheResolution::SkipDataless`, so the xattr read here is both expensive and pointless.

## Change

One-line guard in `materialize_item`:

```rust
if xattrs_enabled && !metadata_summary.is_dataless {
    item.xattrs = read_item_xattrs(&walked.abs_path);
}
```

Plus a comment that captures the rationale, and a regression test.

## Test plan

- [x] New test `materialize_item_skips_xattrs_on_dataless` constructs a `WalkedEntry` against a real tempfile carrying a real xattr, calls `materialize_item` with `is_dataless: true` (asserts `xattrs: None`) and again with `is_dataless: false` (asserts `xattrs: Some(_)`), proving both branches.
- [x] `cargo test -p vykar-core --lib backup` — 114 passed, 0 failed.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.

## Scope / non-goals

This is the smallest possible fix for the dataless xattr round-trip. Issue #133 also discusses:

- Deferring xattr reads until *after* `resolve_cache_hit` to skip them on every cache hit (not only dataless).
- A per-syscall watchdog so a stuck daemon can no longer poison a backup.
- Walker heartbeat events so a frozen progress line at least shows the path that's stuck.
- Possibly parallelizing the stat phase on APFS NVMe.

All of those are larger and worth separate PRs / discussion.

Refs #133.
