### PR TITLE
ci: add nix flake verification and build job

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -39,6 +39,23 @@ jobs:
 
       - uses: cachix/install-nix-action@v31
 
+      # skia-bindings' build script does NOT validate the archive passed via
+      # SKIA_BINARIES_URL (upstream `// TODO: verify key`), so a stale pin
+      # builds successfully against outdated skia binaries instead of failing.
+      # Enforce the version match explicitly.
+      - name: Check skia-binaries pins match Cargo.lock
+        run: |
+          crate_version=$(grep -A1 'name = "skia-bindings"' Cargo.lock | sed -n 's/^version = "\(.*\)"/\1/p')
+          test -n "$crate_version" || { echo "::error::skia-bindings not found in Cargo.lock"; exit 1; }
+          grep -oE 'https://github.com/rust-skia/skia-binaries/releases/download/[^"]+' flake.nix | while read -r url; do
+            tag=$(echo "$url" | cut -d/ -f8)
+            if [ "$tag" != "$crate_version" ]; then
+              echo "::error::flake.nix pins skia-binaries $tag but Cargo.lock has skia-bindings $crate_version: $url"
+              exit 1
+            fi
+          done
+          echo "All skia-binaries pins match skia-bindings $crate_version"
+
       - name: Verify all pinned flake inputs (all platforms)
         run: nix flake archive
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,49 @@
+name: nix
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - flake.nix
+      - flake.lock
+      - .nix/**
+      - Cargo.toml
+      - Cargo.lock
+      - .github/workflows/nix.yml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - flake.nix
+      - flake.lock
+      - .nix/**
+      - Cargo.toml
+      - Cargo.lock
+      - .github/workflows/nix.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+
+      - name: Verify all pinned flake inputs (all platforms)
+        run: nix flake archive
+
+      - name: Evaluate flake outputs for all systems
+        run: nix flake check --all-systems --no-build
+
+      - name: Build packages (x86_64-linux)
+        run: nix build .#vykar .#vykar-server .#vykar-gui --print-build-logs


### PR DESCRIPTION
Adds a `nix` workflow that closes the verification gap seen in #171 / #170, where flake pin updates had no CI coverage and hashes had to be audited by hand.

The job:
1. **Pin-drift guard** — asserts the skia-binaries release tag in `flake.nix` matches the `skia-bindings` version in `Cargo.lock`. This is load-bearing: skia-bindings' build script does **not** validate the archive supplied via `SKIA_BINARIES_URL` (upstream code has a literal `// TODO: verify key`), so a stale pin doesn't fail the build — it silently links the GUI against outdated skia binaries. A first run of this workflow on pre-#171 main built "successfully" against the 0.90.0 binaries while Cargo.lock declared 0.99.0, which is how this was discovered.
2. **`nix flake archive`** — fetches every pinned input and verifies its narHash, including all three skia-binaries tarballs (inputs are not per-system, so this covers Linux and macOS pins in one cheap step). A tampered or stale hash fails here in minutes, with no compilation.
3. **`nix flake check --all-systems --no-build`** — evaluates outputs for x86_64-linux, aarch64-linux, and aarch64-darwin, catching eval-level breakage on platforms we don't build.
4. **`nix build .#vykar .#vykar-server .#vykar-gui`** — full build on x86_64-linux (~55 min uncached).

Triggers are paths-filtered (`flake.nix`, `flake.lock`, `.nix/**`, `Cargo.toml`, `Cargo.lock`, the workflow itself) so ordinary code PRs stay fast. `Cargo.lock` is included because a dependency bump is exactly what broke the flake in #170. Read-only token, no cache service dependencies — builds substitute from cache.nixos.org only.