### PR TITLE
fix(gui): accept an empty passphrase when opening a repository

### DIFF
--- a/crates/vykar-gui/src/repo_helpers.rs
+++ b/crates/vykar-gui/src/repo_helpers.rs
@@ -38,7 +38,11 @@ fn resolve_passphrase_tracked(
         let value = crate::controllers::password_dialog::show_password_dialog_with_error(
             &title, &message, error_line,
         );
-        Ok(value.filter(|v| !v.is_empty()).map(zeroize::Zeroizing::new))
+        // The dialog returns `Some(_)` on submit (including an empty field) and
+        // `None` on cancel/close. An empty string is a valid passphrase — a repo
+        // can be created with one via the CLI — so it must pass through as
+        // `Some("")`; only `None` (dismissed) signals "no passphrase entered".
+        Ok(value.map(zeroize::Zeroizing::new))
     })
 }
 


### PR DESCRIPTION
The password dialog returns `Some(value)` on submit (including an empty
field) and `None` on cancel/close, so the two cases are already
distinguishable. `resolve_passphrase_tracked` was filtering the empty
string to `None`, collapsing "OK on an empty field" into the same state
as a dismissed prompt; downstream `with_passphrase_retry` then reported
the encrypted repo as `Canceled` and never opened it.

An empty passphrase is a legitimate, CLI-supported state (the CLI passes
whatever is typed straight through, so `vykar init` + Enter/Enter creates
such a repo). Let the empty string flow through as `Some("")`; only
`None` (dismissed) now means "no passphrase entered".

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
